### PR TITLE
Fix issue #7 (union type hints for python 3.9.18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,3 @@ Download, browse and delete models in ComfyUI.
 ### Known Issues
 
 - Pinch to Zoom can cause an invisible scrolling bug.
-- After adding/renaming/deleting models, the webpage needs to be reloaded to update the model lists. (Can this be automated?)

--- a/config_loader.py
+++ b/config_loader.py
@@ -6,10 +6,17 @@ class Rule:
     key: any
     value_default: any
     value_type: type
-    value_min: int | float | None
-    value_max: int | float | None
+    value_min: any # int | float | None
+    value_max: any # int | float | None
 
-    def __init__(self, key, value_default, value_type: type, value_min: int | float | None = None, value_max: int | float | None = None):
+    def __init__(
+            self, 
+            key, 
+            value_default, 
+            value_type: type, 
+            value_min: any = None, # int | float | None
+            value_max: any = None, # int | float | None
+    ):
         self.key = key
         self.value_default = value_default
         self.value_type = value_type

--- a/web/model-manager.js
+++ b/web/model-manager.js
@@ -491,7 +491,7 @@ class ImageSelect {
                 if (file) {
                     el_uploadPreview.src = URL.createObjectURL(file);
                 }
-                else {
+                if (el_uploadPreview.src === "") {
                     el_uploadPreview.src = el_defaultUri.dataset.noimage;
                 }
             },

--- a/web/model-manager.js
+++ b/web/model-manager.js
@@ -491,7 +491,7 @@ class ImageSelect {
                 if (file) {
                     el_uploadPreview.src = URL.createObjectURL(file);
                 }
-                if (el_uploadPreview.src === "") {
+                else {
                     el_uploadPreview.src = el_defaultUri.dataset.noimage;
                 }
             },

--- a/web/model-manager.js
+++ b/web/model-manager.js
@@ -3503,6 +3503,8 @@ class ModelManager extends ComfyDialog {
         
         this.#modelTab.updateModelGrid();
         await this.#tryHideModelInfo(false);
+        
+        document.getElementById("comfy-refresh-button")?.click();
     }
     
     /**


### PR DESCRIPTION
Fix https://github.com/hayden-fr/ComfyUI-Model-Manager/issues/7 union type hint crash for Python 3.9.18. 