### PR TITLE
Fix crash if "config" folder does not exist

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -458,7 +458,10 @@ async def get_model_list(request):
     )
 
     model_types = os.listdir(comfyui_model_uri)
-    model_types.remove("configs")
+
+    if "configs" in model_types:
+        model_types.remove("configs")
+
     model_types.sort()
 
     models = {}


### PR DESCRIPTION
This PR fixes an issue with the model manager not loading correctly because I didn't have a configs folder.