### PR TITLE
Add default manager position in settings menu

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -200,7 +200,7 @@ def ui_rules():
         Rule("sidebar-control-always-compact", False, bool),
         Rule("sidebar-default-width", 0.5, float, 0.0, 1.0),
         Rule("sidebar-default-height", 0.5, float, 0.0, 1.0),
-        Rule("sidebar-default-state", "left", str),
+        Rule("sidebar-default-state", "Left", str),
         Rule("text-input-always-hide-search-button", False, bool),
         Rule("text-input-always-hide-clear-button", False, bool),
         

--- a/__init__.py
+++ b/__init__.py
@@ -200,7 +200,7 @@ def ui_rules():
         Rule("sidebar-control-always-compact", False, bool),
         Rule("sidebar-default-width", 0.5, float, 0.0, 1.0),
         Rule("sidebar-default-height", 0.5, float, 0.0, 1.0),
-        Rule("sidebar-default-state", "Left", str),
+        Rule("sidebar-default-state", "None", str),
         Rule("text-input-always-hide-search-button", False, bool),
         Rule("text-input-always-hide-clear-button", False, bool),
         

--- a/__init__.py
+++ b/__init__.py
@@ -200,6 +200,7 @@ def ui_rules():
         Rule("sidebar-control-always-compact", False, bool),
         Rule("sidebar-default-width", 0.5, float, 0.0, 1.0),
         Rule("sidebar-default-height", 0.5, float, 0.0, 1.0),
+        Rule("sidebar-default-state", "left", str),
         Rule("text-input-always-hide-search-button", False, bool),
         Rule("text-input-always-hide-clear-button", False, bool),
         

--- a/web/model-manager.css
+++ b/web/model-manager.css
@@ -10,7 +10,7 @@
     position: fixed;
     overflow: hidden;
     width: 100%;
-    z-index: 2000;
+    z-index: 1100;
     
     /*override comfy-modal settings*/
     border-radius: 0;
@@ -87,6 +87,7 @@
     overflow: hidden;
     color: var(--input-text);
     display: flex;
+    gap: 2px;
     flex-direction: row-reverse;
     flex-wrap: wrap;
 }
@@ -148,7 +149,7 @@
     width: 100%;
 }
 
-.model-manager button {
+.model-manager button, .model-manager .model-manager-head .topbar-right select {
     margin: 0;
 	border: 2px solid var(--border-color);
 }
@@ -166,6 +167,11 @@
     background-color: var(--comfy-menu-bg);
     filter: brightness(1.2);
     cursor: not-allowed;
+}
+
+.model-manager select:hover{
+    filter: brightness(1.2);
+    cursor: pointer;
 }
 
 .model-manager button.block {
@@ -248,7 +254,7 @@
 .model-manager .model-tab-group {
     display: flex;
     gap: 4px;
-    height: 40px;
+    height: 44px;
 }
 
 .model-manager .model-tab-group .tab-button {
@@ -264,6 +270,7 @@
 
 .model-manager .model-tab-group .tab-button.active {
     background-color: var(--bg-color);
+    margin-bottom: -2px;
     cursor: default;
     position: relative;
     z-index: 1;
@@ -451,7 +458,7 @@
 }
 
 .model-manager .comfy-grid .model-label {
-	background-color: rgb(from var(--content-hover-bg) r g b / 0.5);
+	background-color: rgb(from var(--content-hover-bg) r g b / 0.6);
 	width: 100%;
 	height: 2.2rem;
 	position: absolute;
@@ -589,7 +596,8 @@
     position: relative;
     top: 0;
     bottom: 0;
-    font-size: 24px;
+    font-size: 20px;
+    text-align-last: center;
     -o-appearance: none;
     -ms-appearance: none;
     -webkit-appearance: none;
@@ -690,7 +698,7 @@
 
 .model-manager .model-manager-settings input[type="number"],
 .model-manager .tag-generator-settings input[type="number"]{
-    width: 50px;
+    width: 60px;
 }
 
 .model-manager .search-settings-text {

--- a/web/model-manager.js
+++ b/web/model-manager.js
@@ -5373,7 +5373,7 @@ class ModelManager extends ComfyDialog {
         buttonNumb = 4;
       }
       this.#sidebarButtonGroup.children[buttonNumb].click();
-	}
+    }
 
     {
       // set initial sidebar widths & heights

--- a/web/model-manager.js
+++ b/web/model-manager.js
@@ -4611,7 +4611,7 @@ class SettingsView {
         }),
         $select({
           $: (el) => (settings['sidebar-default-state'] = el),
-          textContent: 'Default model manager position',
+          textContent: 'Default model manager position (on start up)',
           options: ['Left', 'Right', 'Top', 'Bottom', 'None'],
         }),	  
         $checkbox({
@@ -5356,37 +5356,27 @@ class ModelManager extends ComfyDialog {
   async #init() {
     await this.#settingsView.reload(false);
     await this.#refreshModels();
-  }
 
-  #updateSidebarSettings = (settings) => {
-	  
-    const newSidebarState = settings['sidebar-default-state'].value;
-    let buttonNumb = 0;
-    if (newSidebarState === 'Left') {
-      buttonNumb = 4;
-    } else if (newSidebarState === 'Right') {
-      buttonNumb = 1;
-    } else if (newSidebarState === 'Top') {
-      buttonNumb = 2;
-    } else if (newSidebarState === 'Bottom') {
-      buttonNumb = 3;
-    }
-    if(!this.#sidebarButtonGroup.children[buttonNumb].classList.contains('radio-button-group-active')){
-      this.#sidebarButtonGroup.children[buttonNumb].click();
-    }
-	
+    const settings = this.#settingsView.elements.settings;
+
     {
-      // initialize buttons' visibility state
-      const hideSearchButtons =
-        settings['text-input-always-hide-search-button'].checked;
-      const hideClearSearchButtons =
-        settings['text-input-always-hide-clear-button'].checked;
-      this.#downloadView.elements.searchButton.style.display = hideSearchButtons
-        ? 'none'
-        : '';
-      this.#downloadView.elements.clearSearchButton.style.display =
-        hideClearSearchButtons ? 'none' : '';
-    }
+      // set initial sidebar state
+      const newSidebarState = settings['sidebar-default-state'].value;
+      let buttonNumb = 0;
+      if (newSidebarState === 'Right') {
+        buttonNumb = 1;
+      } else if (newSidebarState === 'Top') {
+        buttonNumb = 2;
+      } else if (newSidebarState === 'Bottom') {
+        buttonNumb = 3;
+      } else if (newSidebarState === 'Left') {
+        buttonNumb = 4;
+      }
+      const button = this.#sidebarButtonGroup.children[buttonNumb];
+      if(!button.classList.contains('radio-button-group-active')){
+        button.click();
+      }
+	}
 
     {
       // set initial sidebar widths & heights
@@ -5427,6 +5417,21 @@ class ModelManager extends ComfyDialog {
         '--model-manager-sidebar-height-bottom',
         bottomPixels,
       );
+    }
+  }
+
+  #updateSidebarSettings = (settings) => {
+    {
+      // update buttons' visibility state
+      const hideSearchButtons =
+        settings['text-input-always-hide-search-button'].checked;
+      const hideClearSearchButtons =
+        settings['text-input-always-hide-clear-button'].checked;
+      this.#downloadView.elements.searchButton.style.display = hideSearchButtons
+        ? 'none'
+        : '';
+      this.#downloadView.elements.clearSearchButton.style.display =
+        hideClearSearchButtons ? 'none' : '';
     }
   }
 

--- a/web/model-manager.js
+++ b/web/model-manager.js
@@ -4612,7 +4612,7 @@ class SettingsView {
         $select({
           $: (el) => (settings['sidebar-default-state'] = el),
           textContent: 'Default model manager position',
-          options: ['left', 'right', 'top', 'bottom', 'none'],
+          options: ['Left', 'Right', 'Top', 'Bottom', 'None'],
         }),	  
         $checkbox({
           $: (el) => (settings['model-real-time-search'] = el),
@@ -4922,9 +4922,7 @@ function GenerateSidebarToggleRadioAndSelect(labels, activationCallbacks = []) {
     );
   }
   radioButtonGroup.append.apply(radioButtonGroup, buttons);
-  buttons[0].click();
   buttons[0].style.display = 'none';
-
   return [radioButtonGroup, select];
 }
 
@@ -5031,11 +5029,7 @@ class ModelManager extends ComfyDialog {
         ['◼', '◨', '⬒', '⬓', '◧'],
         [
           () => {
-            const element = this.element;
-            if (element) {
-              // callback on initialization as default state
-              element.dataset['sidebarState'] = 'none';
-            }
+            this.element.dataset['sidebarState'] = 'none';
           },
           () => {
             this.element.dataset['sidebarState'] = 'right';
@@ -5364,11 +5358,23 @@ class ModelManager extends ComfyDialog {
     await this.#refreshModels();
   }
 
-  /**
-   * @param {settings: Object}
-   * @return {void}
-   */
   #updateSidebarSettings = (settings) => {
+	  
+    const newSidebarState = settings['sidebar-default-state'].value;
+    let buttonNumb = 0;
+    if (newSidebarState === 'Left') {
+      buttonNumb = 4;
+    } else if (newSidebarState === 'Right') {
+      buttonNumb = 1;
+    } else if (newSidebarState === 'Top') {
+      buttonNumb = 2;
+    } else if (newSidebarState === 'Bottom') {
+      buttonNumb = 3;
+    }
+    if(!this.#sidebarButtonGroup.children[buttonNumb].classList.contains('radio-button-group-active')){
+      this.#sidebarButtonGroup.children[buttonNumb].click();
+    }
+	
     {
       // initialize buttons' visibility state
       const hideSearchButtons =
@@ -5390,7 +5396,6 @@ class ModelManager extends ComfyDialog {
       const xDecimal = settings['sidebar-default-width'].value;
       const yDecimal = settings['sidebar-default-height'].value;
 
-      this.element.dataset['sidebarState'] = settings['sidebar-default-state'].value;
       this.element.dataset['sidebarLeftWidthDecimal'] = xDecimal;
       this.element.dataset['sidebarRightWidthDecimal'] = xDecimal;
       this.element.dataset['sidebarTopHeightDecimal'] = yDecimal;

--- a/web/model-manager.js
+++ b/web/model-manager.js
@@ -5372,10 +5372,7 @@ class ModelManager extends ComfyDialog {
       } else if (newSidebarState === 'Left') {
         buttonNumb = 4;
       }
-      const button = this.#sidebarButtonGroup.children[buttonNumb];
-      if(!button.classList.contains('radio-button-group-active')){
-        button.click();
-      }
+      this.#sidebarButtonGroup.children[buttonNumb].click();
 	}
 
     {


### PR DESCRIPTION
- Selection default manager position in settings menu
- When Reload or Save buttons are pressed, size and position of the manager changes immediately
- Looks like variables showCopyButton and showAddButton was mixed up
- Github issues link now opens in a new tab
- Changed z-index in css so that the manager doesn't block the search node menu and notifications
- Few of minor changes in css
