### PR TITLE
Fix image path resolution for windows

### DIFF
--- a/py/utils.py
+++ b/py/utils.py
@@ -137,6 +137,7 @@ def file_list_to_name_dict(files: list[str]):
     file_dict: dict[str, str] = {}
     for file in files:
         filename = os.path.splitext(file)[0]
+        filename = filename.replace(os.path.sep, "/")
         file_dict[filename] = file
     return file_dict
 


### PR DESCRIPTION
Fixes: #39

`image_dict` in `scan_models` has different path style than what was used for lookup.