### PR TITLE
Skip hidden model files

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -130,7 +130,7 @@ async def read_models(request):
     Scan all models and read their information.
     """
     try:
-        result = services.scan_models()
+        result = services.scan_models(request)
         return web.json_response({"success": True, "data": result})
     except Exception as e:
         error_msg = f"Read models failed: {str(e)}"
@@ -232,7 +232,7 @@ async def download_model_info(request):
     post = await utils.get_request_body(request)
     try:
         scan_mode = post.get("scanMode", "diff")
-        await services.download_model_info(scan_mode)
+        await services.download_model_info(scan_mode, request)
         return web.json_response({"success": True})
     except Exception as e:
         error_msg = f"Download model info failed: {str(e)}"
@@ -288,7 +288,7 @@ async def migrate_legacy_information(request):
     Migrate legacy information.
     """
     try:
-        await services.migrate_legacy_information()
+        await services.migrate_legacy_information(request)
         return web.json_response({"success": True})
     except Exception as e:
         error_msg = f"Migrate model info failed: {str(e)}"

--- a/py/config.py
+++ b/py/config.py
@@ -12,6 +12,9 @@ setting_key = {
     "download": {
         "max_task_count": "ModelManager.Download.MaxTaskCount",
     },
+    "scan": {
+        "include_hidden_files": "ModelManager.Scan.IncludeHiddenFiles"
+    },
 }
 
 user_agent = "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"

--- a/py/utils.py
+++ b/py/utils.py
@@ -103,9 +103,7 @@ def download_web_distribution(version: str):
 
         print_info("Extracting web distribution...")
         with tarfile.open(temp_file, "r:gz") as tar:
-            members = [
-                member for member in tar.getmembers() if member.name.startswith("web/")
-            ]
+            members = [member for member in tar.getmembers() if member.name.startswith("web/")]
             tar.extractall(path=config.extension_uri, members=members)
 
         os.remove(temp_file)
@@ -154,9 +152,7 @@ def get_valid_full_path(model_type: str, path_index: int, filename: str):
     if os.path.isfile(full_path):
         return full_path
     elif os.path.islink(full_path):
-        raise RuntimeError(
-            f"WARNING path {full_path} exists but doesn't link anywhere, skipping."
-        )
+        raise RuntimeError(f"WARNING path {full_path} exists but doesn't link anywhere, skipping.")
 
 
 def get_download_path():
@@ -166,11 +162,29 @@ def get_download_path():
     return download_path
 
 
-def recursive_search_files(directory: str):
-    files, folder_all = folder_paths.recursive_search(
-        directory, excluded_dir_names=[".git"]
-    )
-    return [normalize_path(f) for f in files]
+def recursive_search_files(directory: str, request):
+    if not os.path.isdir(directory):
+        return []
+
+    excluded_dir_names = [".git"]
+    result = []
+    include_hidden_files = get_setting_value(request, "scan.include_hidden_files", False)
+
+    for dirpath, subdirs, filenames in os.walk(directory, followlinks=True, topdown=True):
+        subdirs[:] = [d for d in subdirs if d not in excluded_dir_names]
+        if not include_hidden_files:
+            subdirs[:] = [d for d in subdirs if not d.startswith(".")]
+            filenames[:] = [f for f in filenames if not f.startswith(".")]
+
+        for file_name in filenames:
+            try:
+                relative_path = os.path.relpath(os.path.join(dirpath, file_name), directory)
+                result.append(relative_path)
+            except:
+                logging.warning(f"Warning: Unable to access {file_name}. Skipping this file.")
+                continue
+
+    return [normalize_path(f) for f in result]
 
 
 def search_files(directory: str):

--- a/src/hooks/config.ts
+++ b/src/hooks/config.ts
@@ -239,5 +239,12 @@ function useAddConfigSettings(store: import('hooks/store').StoreProvider) {
         })
       },
     })
+
+    app.ui?.settings.addSetting({
+      id: 'ModelManager.Scan.IncludeHiddenFiles',
+      name: 'Include hidden files(start with .)',
+      defaultValue: false,
+      type: 'boolean',
+    })
   })
 }


### PR DESCRIPTION
Resolve #63 

By default, files or folders starting with . are no longer scanned. On posix systems, they are hidden files. 

Toggle `Include hidden files (start with .)` in the settings to enable or disable scanning for hidden files.