### PR TITLE
Feature scan extra folders

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -23,7 +23,6 @@ if len(uninstalled_package) > 0:
 
 # Init config settings
 config.extension_uri = extension_uri
-utils.resolve_model_base_paths()
 
 version = utils.get_current_version()
 utils.download_web_distribution(version)
@@ -95,7 +94,7 @@ async def get_model_paths(request):
     """
     Returns the base folders for models.
     """
-    model_base_paths = config.model_base_paths
+    model_base_paths = utils.resolve_model_base_paths()
     return web.json_response({"success": True, "data": model_base_paths})
 
 

--- a/py/config.py
+++ b/py/config.py
@@ -1,7 +1,6 @@
 extension_tag = "ComfyUI Model Manager"
 
 extension_uri: str = None
-model_base_paths: dict[str, list[str]] = {}
 
 
 setting_key = {

--- a/py/services.py
+++ b/py/services.py
@@ -17,7 +17,7 @@ def scan_models():
         for path_index, base_path in enumerate(folders):
             files = utils.recursive_search_files(base_path)
 
-            models = folder_paths.filter_files_extensions(files, extensions)
+            models = folder_paths.filter_files_extensions(files, folder_paths.supported_pt_extensions)
 
             for fullname in models:
                 fullname = utils.normalize_path(fullname)
@@ -145,7 +145,7 @@ async def download_model_info(scan_mode: str):
         for path_index, base_path in enumerate(folders):
             files = utils.recursive_search_files(base_path)
 
-            models = folder_paths.filter_files_extensions(files, extensions)
+            models = folder_paths.filter_files_extensions(files, folder_paths.supported_pt_extensions)
 
             for fullname in models:
                 fullname = utils.normalize_path(fullname)
@@ -206,7 +206,7 @@ async def migrate_legacy_information():
         for path_index, base_path in enumerate(folders):
             files = utils.recursive_search_files(base_path)
 
-            models = folder_paths.filter_files_extensions(files, extensions)
+            models = folder_paths.filter_files_extensions(files, folder_paths.supported_pt_extensions)
 
             for fullname in models:
                 fullname = utils.normalize_path(fullname)

--- a/py/services.py
+++ b/py/services.py
@@ -10,7 +10,7 @@ from . import searcher
 
 def scan_models():
     result = []
-    model_base_paths = config.model_base_paths
+    model_base_paths = utils.resolve_model_base_paths()
     for model_type in model_base_paths:
 
         folders, extensions = folder_paths.folder_names_and_paths[model_type]
@@ -34,9 +34,7 @@ def scan_models():
                     image_state = os.stat(abs_image_path)
                     image_timestamp = round(image_state.st_mtime_ns / 1000000)
                     image_name = f"{image_name}?ts={image_timestamp}"
-                model_preview = (
-                    f"/model-manager/preview/{model_type}/{path_index}/{image_name}"
-                )
+                model_preview = f"/model-manager/preview/{model_type}/{path_index}/{image_name}"
 
                 model_info = {
                     "fullname": fullname,
@@ -140,7 +138,7 @@ def fetch_model_info(model_page: str):
 
 async def download_model_info(scan_mode: str):
     utils.print_info(f"Download model info for {scan_mode}")
-    model_base_paths = config.model_base_paths
+    model_base_paths = utils.resolve_model_base_paths()
     for model_type in model_base_paths:
 
         folders, extensions = folder_paths.folder_names_and_paths[model_type]
@@ -161,16 +159,8 @@ async def download_model_info(scan_mode: str):
                 has_preview = os.path.isfile(abs_image_path)
 
                 description_name = utils.get_model_description_name(abs_model_path)
-                abs_description_path = (
-                    utils.join_path(base_path, description_name)
-                    if description_name
-                    else None
-                )
-                has_description = (
-                    os.path.isfile(abs_description_path)
-                    if abs_description_path
-                    else False
-                )
+                abs_description_path = utils.join_path(base_path, description_name) if description_name else None
+                has_description = os.path.isfile(abs_description_path) if abs_description_path else False
 
                 try:
 
@@ -185,27 +175,19 @@ async def download_model_info(scan_mode: str):
                     utils.print_debug(f"Calculate sha256 for {abs_model_path}")
                     hash_value = utils.calculate_sha256(abs_model_path)
                     utils.print_info(f"Searching model info by hash {hash_value}")
-                    model_info = searcher.CivitaiModelSearcher().search_by_hash(
-                        hash_value
-                    )
+                    model_info = searcher.CivitaiModelSearcher().search_by_hash(hash_value)
 
                     preview_url_list = model_info.get("preview", [])
-                    preview_image_url = (
-                        preview_url_list[0] if preview_url_list else None
-                    )
+                    preview_image_url = preview_url_list[0] if preview_url_list else None
                     if preview_image_url:
                         utils.print_debug(f"Save preview image to {abs_image_path}")
-                        utils.save_model_preview_image(
-                            abs_model_path, preview_image_url
-                        )
+                        utils.save_model_preview_image(abs_model_path, preview_image_url)
 
                     description = model_info.get("description", None)
                     if description:
                         utils.save_model_description(abs_model_path, description)
                 except Exception as e:
-                    utils.print_error(
-                        f"Failed to download model info for {abs_model_path}: {e}"
-                    )
+                    utils.print_error(f"Failed to download model info for {abs_model_path}: {e}")
 
     utils.print_debug("Completed scan model information.")
 
@@ -217,7 +199,7 @@ async def migrate_legacy_information():
 
     utils.print_info(f"Migrating legacy information...")
 
-    model_base_paths = config.model_base_paths
+    model_base_paths = utils.resolve_model_base_paths()
     for model_type in model_base_paths:
 
         folders, extensions = folder_paths.folder_names_and_paths[model_type]

--- a/py/utils.py
+++ b/py/utils.py
@@ -103,9 +103,7 @@ def download_web_distribution(version: str):
 
         print_info("Extracting web distribution...")
         with tarfile.open(temp_file, "r:gz") as tar:
-            members = [
-                member for member in tar.getmembers() if member.name.startswith("web/")
-            ]
+            members = [member for member in tar.getmembers() if member.name.startswith("web/")]
             tar.extractall(path=config.extension_uri, members=members)
 
         os.remove(temp_file)
@@ -120,21 +118,21 @@ def download_web_distribution(version: str):
 
 def resolve_model_base_paths():
     folders = list(folder_paths.folder_names_and_paths.keys())
-    config.model_base_paths = {}
+    model_base_paths = {}
+    folder_black_list = ["configs", "custom_nodes"]
     for folder in folders:
-        if folder == "configs":
-            continue
-        if folder == "custom_nodes":
+        if folder in folder_black_list:
             continue
         folders = folder_paths.get_folder_paths(folder)
-        config.model_base_paths[folder] = [normalize_path(f) for f in folders]
+        model_base_paths[folder] = [normalize_path(f) for f in folders]
+    return model_base_paths
 
 
 def get_full_path(model_type: str, path_index: int, filename: str):
     """
     Get the absolute path in the model type through string concatenation.
     """
-    folders = config.model_base_paths.get(model_type, [])
+    folders = resolve_model_base_paths().get(model_type, [])
     if not path_index < len(folders):
         raise RuntimeError(f"PathIndex {path_index} is not in {model_type}")
     base_path = folders[path_index]
@@ -146,7 +144,7 @@ def get_valid_full_path(model_type: str, path_index: int, filename: str):
     """
     Like get_full_path but it will check whether the file is valid.
     """
-    folders = config.model_base_paths.get(model_type, [])
+    folders = resolve_model_base_paths().get(model_type, [])
     if not path_index < len(folders):
         raise RuntimeError(f"PathIndex {path_index} is not in {model_type}")
     base_path = folders[path_index]
@@ -154,9 +152,7 @@ def get_valid_full_path(model_type: str, path_index: int, filename: str):
     if os.path.isfile(full_path):
         return full_path
     elif os.path.islink(full_path):
-        raise RuntimeError(
-            f"WARNING path {full_path} exists but doesn't link anywhere, skipping."
-        )
+        raise RuntimeError(f"WARNING path {full_path} exists but doesn't link anywhere, skipping.")
 
 
 def get_download_path():
@@ -167,9 +163,7 @@ def get_download_path():
 
 
 def recursive_search_files(directory: str):
-    files, folder_all = folder_paths.recursive_search(
-        directory, excluded_dir_names=[".git"]
-    )
+    files, folder_all = folder_paths.recursive_search(directory, excluded_dir_names=[".git"])
     return [normalize_path(f) for f in files]
 
 


### PR DESCRIPTION
Some extensions may inject additional directories into folder_paths. The way of pre-resolving the model directory makes this behavior uncontrollable, so change it to real-time loading.

And the problem of scanning out non-model files has been fixed.