### PR TITLE
fix: find subfolder incorrect

### DIFF
--- a/src/components/DialogExplorer.vue
+++ b/src/components/DialogExplorer.vue
@@ -193,7 +193,10 @@ const sortOrderOptions = ref(
 const currentDataList = computed(() => {
   let renderedList = dataTreeList.value
   for (const folderItem of folderPaths.value) {
-    const found = findFolder(renderedList, folderItem.name)
+    const found = findFolder(renderedList, {
+      basename: folderItem.name,
+      pathIndex: folderItem.pathIndex,
+    })
     renderedList = found?.children || []
   }
 

--- a/src/hooks/explorer.ts
+++ b/src/hooks/explorer.ts
@@ -5,6 +5,7 @@ import { computed, ref, watch } from 'vue'
 
 export interface FolderPathItem {
   name: string
+  pathIndex: number
   icon?: string
   onClick: () => void
   children: SelectOptions[]
@@ -91,10 +92,11 @@ export const useModelExplorer = () => {
     return [root]
   })
 
-  function findFolder(list: ModelTreeNode[], name: string) {
-    return find(list, { isFolder: true, basename: name }) as
-      | ModelFolder
-      | undefined
+  function findFolder(
+    list: ModelTreeNode[],
+    feature: { basename: string; pathIndex: number },
+  ) {
+    return find(list, { ...feature, isFolder: true }) as ModelFolder | undefined
   }
 
   function findFolders(list: ModelTreeNode[]) {
@@ -118,7 +120,12 @@ export const useModelExplorer = () => {
 
     let levelFolders = findFolders(dataTreeList.value)
     for (const [index, part] of pathParts.entries()) {
-      const currentFolder = findFolder(levelFolders, part)
+      const pathIndex = index < 2 ? 0 : item.pathIndex
+
+      const currentFolder = findFolder(levelFolders, {
+        basename: part,
+        pathIndex: pathIndex,
+      })
       if (!currentFolder) {
         break
       }
@@ -126,6 +133,7 @@ export const useModelExplorer = () => {
       levelFolders = findFolders(currentFolder.children ?? [])
       folderItems.push({
         name: currentFolder.basename,
+        pathIndex: pathIndex,
         icon: index === 0 ? 'pi pi-desktop' : '',
         onClick: () => {
           openFolder(currentFolder)


### PR DESCRIPTION
Resolve the issue of incorrect subfolder name lookup when configuring multiple extra_model_paths.