### PR TITLE
Error file size

### DIFF
--- a/py/download.py
+++ b/py/download.py
@@ -457,8 +457,10 @@ class ModelDownload:
 
         # When parsing model information from HuggingFace API,
         # the file size was not found and needs to be obtained from the response header.
-        if total_size == 0:
-            total_size = float(response.headers.get("content-length", 0))
+        # Fixed issue #169. Some model information from Civitai, providing the wrong file size
+        response_total_size = float(response.headers.get("content-length", 0))
+        if total_size == 0 or total_size != response_total_size:
+            total_size = response_total_size
             task_content.sizeBytes = total_size
             task_status.totalSize = total_size
             self.set_task_content(task_id, task_content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-model-manager"
 description = "Manage models: browsing, download and delete."
-version = "2.5.4"
+version = "2.5.5"
 license = { file = "LICENSE" }
 dependencies = ["markdownify"]
 


### PR DESCRIPTION
Some model information from Civitai, providing the wrong file size.

Get the correct file size from the request.