### PR TITLE
Secure storage API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ web/
 
 # config
 config/
+
+# private info
+private.key

--- a/py/download.py
+++ b/py/download.py
@@ -2,6 +2,7 @@ import os
 import uuid
 import time
 import requests
+import base64
 
 
 import folder_paths
@@ -113,6 +114,13 @@ class ApiKey:
             utils.set_setting_value(request, "api_key.civitai", None)
             utils.set_setting_value(request, "api_key.huggingface", None)
         self.__store = utils.load_dict_pickle_file(self.__cache_file)
+        # Desensitization returns
+        result: dict[str, str] = {}
+        for key in self.__store:
+            v = self.__store[key]
+            if v is not None:
+                result[key] = v[:4] + "****" + v[-4:]
+        return result
 
     def get_value(self, key: str):
         return self.__store.get(key, None)
@@ -135,7 +143,19 @@ class ModelDownload:
             """
             Init download setting.
             """
-            self.api_key.init(request)
+            result = self.api_key.init(request)
+            return web.json_response({"success": True, "data": result})
+
+        @routes.post("/model-manager/download/setting")
+        async def set_download_setting(request):
+            """
+            Set download setting.
+            """
+            json_data = await request.json()
+            key = json_data.get("key", None)
+            value = json_data.get("value", None)
+            value = base64.b64decode(value).decode("utf-8") if value is not None else None
+            self.api_key.set_value(key, value)
             return web.json_response({"success": True})
 
         @routes.get("/model-manager/download/task")
@@ -372,12 +392,12 @@ class ModelDownload:
 
                 download_platform = task_status.platform
                 if download_platform == "civitai":
-                    api_key = utils.get_setting_value(request, "api_key.civitai")
+                    api_key = self.api_key.get_value("civitai")
                     if api_key:
                         headers["Authorization"] = f"Bearer {api_key}"
 
                 elif download_platform == "huggingface":
-                    api_key = utils.get_setting_value(request, "api_key.huggingface")
+                    api_key = self.api_key.get_value("huggingface")
                     if api_key:
                         headers["Authorization"] = f"Bearer {api_key}"
 

--- a/src/components/SettingApiKey.vue
+++ b/src/components/SettingApiKey.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="p-4">
+    <InputText
+      class="w-full"
+      v-model="content"
+      placeholder="Set New API Key"
+      autocomplete="off"
+    ></InputText>
+    <div class="mt-4 flex items-center justify-between">
+      <div>
+        <span v-show="showError" class="text-red-400">
+          API Key Not Allow Empty
+        </span>
+      </div>
+      <Button label="Save" autofocus @click="saveKeybinding"></Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useDialog } from 'hooks/dialog'
+import { request } from 'hooks/request'
+import { useToast } from 'hooks/toast'
+import Button from 'primevue/button'
+import InputText from 'primevue/inputtext'
+import { ref, toValue } from 'vue'
+
+interface Props {
+  keyField: string
+  setter: (val: string) => void
+}
+
+const props = defineProps<Props>()
+
+const { close } = useDialog()
+const { toast } = useToast()
+
+const content = ref<string>()
+const showError = ref<boolean>(false)
+
+const saveKeybinding = async () => {
+  const value = toValue(content)
+  if (!value) {
+    showError.value = true
+    return
+  }
+
+  showError.value = false
+  const key = toValue(props.keyField)
+
+  try {
+    const encodeValue = value ? btoa(value) : null
+    await request('/download/setting', {
+      method: 'POST',
+      body: JSON.stringify({ key, value: encodeValue }),
+    })
+    const desString = value ? value.slice(0, 4) + '****' + value.slice(-4) : ''
+    props.setter(desString)
+    close()
+  } catch (error) {
+    toast.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: error.message,
+      life: 3000,
+    })
+  }
+}
+</script>

--- a/src/hooks/download.ts
+++ b/src/hooks/download.ts
@@ -84,7 +84,16 @@ export const useDownload = defineStore('download', (store) => {
     })
   })
 
+  // Initial download settings
+  // Migrate API keys from user settings to private key
+  const init = async () => {
+    const res = await request('/download/init', { method: 'POST' })
+    store.config.apiKeyInfo.value = res
+  }
+
   onBeforeMount(() => {
+    init()
+
     api.addEventListener('reconnected', () => {
       refresh()
     })


### PR DESCRIPTION
Migrate API Key's storage from user setting to local storage. Should the situation where the user settings are sent together when sending error reports.