### PR TITLE
feat(search): add multi-token regex and wildcard support

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -80,8 +80,25 @@ onMounted(() => {
     })
   }
 
+  const toggleLayout = () => {
+    // flip the flat setting
+    const newValue = !config.flat.value
+    config.flat.value = newValue
+
+    // persist so it survives reloads
+    app.ui?.settings.setSettingValue('ModelManager.UI.Flat', newValue)
+
+    // close the current dialog (because it is keepAlive)
+    dialog.closeAll()
+
+    // reopen with the new layout
+    openManagerDialog()
+  }
+
   const openManagerDialog = () => {
     const { cardWidth, gutter, aspect, flat } = config
+    // choose icon depending on current layout
+    const layoutIcon = flat.value ? 'pi pi-folder-open' : 'pi pi-th-large'
 
     if (firstOpenManager.value) {
       models.refresh(true)
@@ -98,6 +115,14 @@ onMounted(() => {
           key: 'scanning',
           icon: 'mdi mdi-folder-search-outline text-lg',
           command: openModelScanning,
+        },
+        {
+          key: 'toggle-layout',
+          icon: layoutIcon,
+          command: toggleLayout,
+          tooltip: flat.value
+            ? t('switchToFolderView')
+            : t('switchToFlatView'),
         },
         {
           key: 'refresh',


### PR DESCRIPTION
This PR improves the model search/filter functionality in DialogManager.vue.

### Changes

- Replaced substring .includes() filtering with regex-based matching.

- Added support for * wildcards (expanded to .* in regex).

- Added support for multiple tokens separated by spaces.
  - Each token is compiled into its own regex.
  - A model must match all tokens (AND logic) in either its basename or subFolder.

- Preserves case-insensitivity for ease of use.

### Examples

  - wan → matches any model with “wan” in name or folder.
  - *wan* → wildcard match.
  - /WAN-/ anime → requires both /WAN-/ and anime to be present.

### Impact

  - No breaking changes.
  - Greatly improves search flexibility for large model libraries.
  - Performance remains efficient (per-token regex tests).