### PR TITLE
feat(ui): add hidden-files toggle and i18n updates

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -95,10 +95,36 @@ onMounted(() => {
     openManagerDialog()
   }
 
+    const toggleHiddenFiles = () => {
+    // read current setting, default false if unset
+    const current =
+      app.ui?.settings.getSettingValue('ModelManager.Scan.IncludeHiddenFiles') ??
+      false
+    const newVal = !current
+
+    // persist setting
+    app.ui?.settings.setSettingValue('ModelManager.Scan.IncludeHiddenFiles', newVal)
+
+    // refresh models so the toggle takes effect
+    refreshModelsAndConfig()
+
+    // close and reopen manager to redraw content
+    dialog.closeAll()
+    openManagerDialog()
+  }
+
   const openManagerDialog = () => {
     const { cardWidth, gutter, aspect, flat } = config
     // choose icon depending on current layout
     const layoutIcon = flat.value ? 'pi pi-folder-open' : 'pi pi-th-large'
+    // determine hidden files setting
+    const includeHidden =
+      app.ui?.settings.getSettingValue('ModelManager.Scan.IncludeHiddenFiles') ??
+      false
+    const hiddenIcon = includeHidden ? 'pi pi-eye' : 'pi pi-eye-slash'
+    const hiddenTooltip = includeHidden
+      ? t('hideHiddenFiles')
+      : t('showHiddenFiles')
 
     if (firstOpenManager.value) {
       models.refresh(true)
@@ -115,6 +141,12 @@ onMounted(() => {
           key: 'scanning',
           icon: 'mdi mdi-folder-search-outline text-lg',
           command: openModelScanning,
+        },
+        {
+          key: 'toggle-hidden',
+          icon: hiddenIcon,
+          command: toggleHiddenFiles,
+          tooltip: hiddenTooltip,
         },
         {
           key: 'toggle-layout',

--- a/src/App.vue
+++ b/src/App.vue
@@ -80,8 +80,25 @@ onMounted(() => {
     })
   }
 
+  const toggleLayout = () => {
+    // flip the flat setting
+    const newValue = !config.flat.value
+    config.flat.value = newValue
+
+    // persist so it survives reloads
+    app.ui?.settings.setSettingValue('ModelManager.UI.Flat', newValue)
+
+    // close the current dialog (because it is keepAlive)
+    dialog.closeAll()
+
+    // reopen with the new layout
+    openManagerDialog()
+  }
+
   const openManagerDialog = () => {
     const { cardWidth, gutter, aspect, flat } = config
+    // choose icon depending on current layout
+    const layoutIcon = flat.value ? 'pi pi-folder-open' : 'pi pi-th-large'
 
     if (firstOpenManager.value) {
       models.refresh(true)
@@ -98,6 +115,14 @@ onMounted(() => {
           key: 'scanning',
           icon: 'mdi mdi-folder-search-outline text-lg',
           command: openModelScanning,
+        },
+        {
+          key: 'toggle-layout',
+          icon: layoutIcon,
+          command: toggleLayout,
+          tooltip: flat.value
+            ? t('switchToFolderView')
+            : t('switchToFlatView'),
         },
         {
           key: 'refresh',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -73,5 +73,9 @@
     "ui": "UI",
     "cardSize": "Card Size",
     "useFlatUI": "Flat Layout"
-  }
+  },
+  "switchToFolderView": "Switch to Folder View",
+  "switchToFlatView": "Switch to Flat View",
+  "hideHiddenFiles": "Hide hidden files",
+  "showHiddenFiles": "Show hidden files"
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -73,5 +73,9 @@
     "ui": "外观",
     "cardSize": "卡片尺寸",
     "useFlatUI": "展平布局"
-  }
+  },
+  "switchToFolderView": "切换到文件夹视图",
+  "switchToFlatView": "切换到平铺视图",
+  "hideHiddenFiles": "隐藏隐藏文件",
+  "showHiddenFiles": "显示隐藏文件"
 }


### PR DESCRIPTION
- Added a new header button in the Model Manager to toggle display of
  hidden files/folders (dot-prefixed). This updates the existing
  `ModelManager.Scan.IncludeHiddenFiles` setting, persists it, and
  refreshes the dialog so changes apply immediately.
- Button shows dynamic icon + tooltip:
  - 👁 "Show hidden files"
  - 👁‍🗨 "Hide hidden files"

- Updated i18n locale files:
  - en.json: added strings for both the layout toggle and hidden-files toggle
  - zh.json: added translations for the same strings

Note: normally these i18n keys would have been split between the layout
commit and this one, but they are grouped here for simplicity so all UI
strings for the new header buttons are introduced together.
