### PR TITLE
Add path traversal check

### DIFF
--- a/py/utils.py
+++ b/py/utils.py
@@ -192,6 +192,10 @@ def get_full_path(model_type: str, path_index: int, filename: str):
         raise RuntimeError(f"PathIndex {path_index} is not in {model_type}")
     base_path = folders[path_index]
     full_path = join_path(base_path, filename)
+    real_base = os.path.realpath(base_path)
+    real_full = os.path.realpath(full_path)
+    if not (real_full == real_base or real_full.startswith(real_base + os.sep)):
+        raise RuntimeError(f"Path traversal detected: filename escapes model directory")
     return full_path
 
 
@@ -199,11 +203,7 @@ def get_valid_full_path(model_type: str, path_index: int, filename: str):
     """
     Like get_full_path but it will check whether the file is valid.
     """
-    folders = resolve_model_base_paths().get(model_type, [])
-    if not path_index < len(folders):
-        raise RuntimeError(f"PathIndex {path_index} is not in {model_type}")
-    base_path = folders[path_index]
-    full_path = join_path(base_path, filename)
+    full_path = get_full_path(model_type, path_index, filename)
     if os.path.isfile(full_path):
         return full_path
     elif os.path.islink(full_path):


### PR DESCRIPTION
## Summary

This PR fixes four path traversal vulnerabilities that could allow an attacker to read or write arbitrary files on the server's filesystem. Only a issue if hosted not localy.

### Vulnerabilities fixed

**1. `utils.py` — `get_full_path()` missing traversal check (read)**
The core path-building function constructed the final path via `join_path` but never verified the result stayed inside the model base directory. Any caller passing a `filename` like `../../etc/passwd` would silently escape the intended directory.

Fix: added `os.path.realpath()` comparison — if the resolved path does not start with the resolved base directory, a `RuntimeError` is raised.

**2. `information.py` — `GET /model-manager/preview/{type}/{index}/{filename}` (read)**
The route built `abs_path` directly from the URL parameter `filename` via `join_path` without any traversal check. An attacker could request `/model-manager/preview/checkpoints/0/../../path/to/image.webp` and receive the file contents.

Fix: replaced the manual `join_path(base_path, filename)` construction with `utils.get_full_path()`, which now includes the `realpath` check.

**3. `information.py` — `GET /model-manager/preview/download/{filename}` (read)**
The route joined the user-controlled `filename` URL parameter directly onto `download_path` without validation. A traversal sequence in `filename` could expose any readable file on the system.

Fix: added a `os.path.realpath()` check to ensure the resolved preview path stays within `download_path` before serving.

**4. `upload.py` — `POST /model-manager/upload` (write — critical)**
The multipart upload handler used `file_folder` and `filename` directly from the request body to construct paths passed to `open()` and `os.rename()`. An attacker could write to arbitrary locations on the filesystem.

Fix:
- `file_folder` is validated against all known model base directories via `resolve_model_base_paths()` — subdirectories are allowed, anything else is rejected.
- `filename` is checked with `realpath` to ensure the resulting path stays within `file_folder`.
- Added a guard for the case where `file` arrives before `folder` in the multipart stream.